### PR TITLE
Resolves Bug#3

### DIFF
--- a/src/components/ToDoItem.css
+++ b/src/components/ToDoItem.css
@@ -27,6 +27,13 @@
 .ToDoItem .button {
   cursor: pointer;
   margin-inline-start: var(--spacing);
+  background-color: transparent;
+  padding: 0;
+  border: none;
+  line-height: inherit;
+  border-radius: unset;
+  color: var(--text-color);
+  outline-offset: 5px;
 }
 
 .ToDoItem .button:hover {

--- a/src/components/ToDoItem.css
+++ b/src/components/ToDoItem.css
@@ -36,6 +36,10 @@
   outline-offset: 5px;
 }
 
+.ToDoItem .button:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .ToDoItem .button:hover {
   color: var(--accent-color-dark);
 }

--- a/src/components/ToDoItem.tsx
+++ b/src/components/ToDoItem.tsx
@@ -32,11 +32,11 @@ export function ToDoItem(props: ToDoItemProps) {
       {
         showDeleteConfirm ? (
           <>
-            <span className="button accent" onClick={() => props.onDelete(props.value)}>Confirm</span>
-            <span className="button" onClick={() => setShowDeleteConfirm(false)}>Cancel</span>
+            <button className="button accent" onClick={() => props.onDelete(props.value)}>Confirm</button>
+            <button className="button" onClick={() => setShowDeleteConfirm(false)}>Cancel</button>
           </>
         ) : (
-          <span className="button accent" onClick={() => setShowDeleteConfirm(true)}>Delete</span>
+          <button className="button accent" onClick={() => setShowDeleteConfirm(true)}>Delete</button>
         )
       }
     </li>


### PR DESCRIPTION
For accessibility reasons, elements with button functionality should use the button tag. 
In the .css, the standard appearance of the button has been ‘hidden,’ and the offset has been managed so that it is visible only during keyboard navigation.